### PR TITLE
Refactor and provide JSON file loaders for endpoints and tokens

### DIFF
--- a/pkg/kubediscovery/model.go
+++ b/pkg/kubediscovery/model.go
@@ -12,10 +12,9 @@ limitations under the License.
 */
 package kubediscovery
 
-// TODO: Sync with kubeadm api type
 type ClusterInfo struct {
-	Type             string
-	Version          string
-	RootCertificates string `json:"rootCertificates"`
-	// TODO: ClusterID, Endpoints
+	// TODO Kind, apiVersion
+	// TODO clusterId, fetchedTime, expiredTime
+	CertificateAuthorities []string `json:"certificateAuthorities,omitempty"`
+	Endpoints              []string `json:"endpoints,omitempty"`
 }


### PR DESCRIPTION
I haven't updated the test yet, just did this to carry on doing what I needed in kubeadm.
